### PR TITLE
fix: store name and symbol properly in collection proxy pattern

### DIFF
--- a/src/core/collection/ERC1155Collection.sol
+++ b/src/core/collection/ERC1155Collection.sol
@@ -28,6 +28,12 @@ contract ERC1155Collection is ERC1155, BaseCollection, IERC2981 {
         return s_symbol;
     }
 
+    // Internal function to set name and symbol for proxy initialization
+    function _setNameAndSymbol(string memory _name, string memory _symbol) internal {
+        s_name = _name;
+        s_symbol = _symbol;
+    }
+
     // Mint a single NFT
     function mint(address to, uint256 amount) external payable {
         // checkMint now auto-updates stage internally

--- a/src/core/collection/ERC721Collection.sol
+++ b/src/core/collection/ERC721Collection.sol
@@ -11,7 +11,30 @@ import {Minted, BatchMinted} from "src/events/CollectionEvents.sol";
 import "src/errors/CollectionErrors.sol";
 
 contract ERC721Collection is ERC721, BaseCollection, IERC2981 {
-    constructor(CollectionParams memory params) ERC721(params.name, params.symbol) BaseCollection(params) {}
+    // Collection metadata - stored separately for proxy pattern compatibility
+    string private s_collectionName;
+    string private s_collectionSymbol;
+
+    constructor(CollectionParams memory params) ERC721(params.name, params.symbol) BaseCollection(params) {
+        s_collectionName = params.name;
+        s_collectionSymbol = params.symbol;
+    }
+
+    // Override name() to return our stored value (needed for proxy pattern)
+    function name() public view override returns (string memory) {
+        return s_collectionName;
+    }
+
+    // Override symbol() to return our stored value (needed for proxy pattern)
+    function symbol() public view override returns (string memory) {
+        return s_collectionSymbol;
+    }
+
+    // Internal function to set name and symbol for proxy initialization
+    function _setNameAndSymbol(string memory _name, string memory _symbol) internal {
+        s_collectionName = _name;
+        s_collectionSymbol = _symbol;
+    }
 
     function mint(address to) external payable {
         // checkMint now auto-updates stage internally

--- a/src/core/proxy/ERC1155CollectionImplementation.sol
+++ b/src/core/proxy/ERC1155CollectionImplementation.sol
@@ -50,6 +50,9 @@ contract ERC1155CollectionImplementation is ERC1155Collection, Initializable {
      * @dev Manually sets state variables that would normally be set in constructors
      */
     function _initializeProxyState(CollectionParams memory params) internal {
+        // Initialize name and symbol for proxy pattern
+        _setNameAndSymbol(params.name, params.symbol);
+        
         // Initialize BaseCollection state variables
         s_description = params.description;
         s_mintPrice = params.mintPrice;
@@ -70,8 +73,7 @@ contract ERC1155CollectionImplementation is ERC1155Collection, Initializable {
         // Create Fee contract for royalty management
         s_feeContract = new Fee(params.owner, params.royaltyFee);
 
-        // Note: ERC1155 name/symbol and URI are handled by the parent constructor
-        // For proxies, we'll need to set the URI manually if needed
+        // Set the URI for ERC1155
         _setURI(params.tokenURI);
     }
 

--- a/src/core/proxy/ERC721CollectionImplementation.sol
+++ b/src/core/proxy/ERC721CollectionImplementation.sol
@@ -48,6 +48,9 @@ contract ERC721CollectionImplementation is ERC721Collection, Initializable {
      * @param params Collection parameters
      */
     function _initializeCollection(CollectionParams memory params) internal {
+        // Initialize name and symbol for proxy pattern
+        _setNameAndSymbol(params.name, params.symbol);
+        
         // Initialize BaseCollection state
         s_description = params.description;
         s_mintPrice = params.mintPrice;

--- a/test/unit/collection/CollectionNameSymbolTest.t.sol
+++ b/test/unit/collection/CollectionNameSymbolTest.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC721CollectionFactory} from "src/core/factory/ERC721CollectionFactory.sol";
+import {ERC1155CollectionFactory} from "src/core/factory/ERC1155CollectionFactory.sol";
+import {ERC721Collection} from "src/core/collection/ERC721Collection.sol";
+import {ERC1155Collection} from "src/core/collection/ERC1155Collection.sol";
+import {CollectionParams} from "src/types/ListingTypes.sol";
+
+contract CollectionNameSymbolTest is Test {
+    ERC721CollectionFactory public erc721Factory;
+    ERC1155CollectionFactory public erc1155Factory;
+    
+    address public alice = address(0xA11ce);
+    
+    function setUp() public {
+        erc721Factory = new ERC721CollectionFactory();
+        erc1155Factory = new ERC1155CollectionFactory();
+    }
+    
+    function test_ERC721_NameAndSymbolAreStoredCorrectly() public {
+        // Create collection params
+        CollectionParams memory params = CollectionParams({
+            name: "Test ERC721 Collection",
+            symbol: "T721",
+            owner: alice,
+            description: "Testing name and symbol storage",
+            mintPrice: 0.01 ether,
+            royaltyFee: 500, // 5%
+            maxSupply: 100,
+            mintLimitPerWallet: 5,
+            mintStartTime: block.timestamp,
+            allowlistMintPrice: 0.008 ether,
+            publicMintPrice: 0.01 ether,
+            allowlistStageDuration: 1 days,
+            tokenURI: "https://test.com/metadata/"
+        });
+        
+        // Create collection
+        address collectionAddress = erc721Factory.createERC721Collection(params);
+        
+        // Cast to ERC721Collection and verify name and symbol
+        ERC721Collection collection = ERC721Collection(collectionAddress);
+        
+        assertEq(collection.name(), "Test ERC721 Collection", "ERC721: Name not stored correctly");
+        assertEq(collection.symbol(), "T721", "ERC721: Symbol not stored correctly");
+    }
+    
+    function test_ERC1155_NameAndSymbolAreStoredCorrectly() public {
+        // Create collection params
+        CollectionParams memory params = CollectionParams({
+            name: "Test ERC1155 Collection",
+            symbol: "T1155",
+            owner: alice,
+            description: "Testing name and symbol storage for ERC1155",
+            mintPrice: 0.01 ether,
+            royaltyFee: 500, // 5%
+            maxSupply: 100,
+            mintLimitPerWallet: 5,
+            mintStartTime: block.timestamp,
+            allowlistMintPrice: 0.008 ether,
+            publicMintPrice: 0.01 ether,
+            allowlistStageDuration: 1 days,
+            tokenURI: "https://test.com/metadata/"
+        });
+        
+        // Create collection
+        address collectionAddress = erc1155Factory.createERC1155Collection(params);
+        
+        // Cast to ERC1155Collection and verify name and symbol
+        ERC1155Collection collection = ERC1155Collection(collectionAddress);
+        
+        assertEq(collection.name(), "Test ERC1155 Collection", "ERC1155: Name not stored correctly");
+        assertEq(collection.symbol(), "T1155", "ERC1155: Symbol not stored correctly");
+    }
+    
+    function test_MultipleCollectionsHaveDifferentNamesAndSymbols() public {
+        // Create first ERC721 collection
+        CollectionParams memory params1 = CollectionParams({
+            name: "First Collection",
+            symbol: "FC",
+            owner: alice,
+            description: "First collection",
+            mintPrice: 0.01 ether,
+            royaltyFee: 500,
+            maxSupply: 100,
+            mintLimitPerWallet: 5,
+            mintStartTime: block.timestamp,
+            allowlistMintPrice: 0.008 ether,
+            publicMintPrice: 0.01 ether,
+            allowlistStageDuration: 1 days,
+            tokenURI: "https://test1.com/metadata/"
+        });
+        
+        // Create second ERC721 collection
+        CollectionParams memory params2 = CollectionParams({
+            name: "Second Collection",
+            symbol: "SC",
+            owner: alice,
+            description: "Second collection",
+            mintPrice: 0.02 ether,
+            royaltyFee: 750,
+            maxSupply: 200,
+            mintLimitPerWallet: 10,
+            mintStartTime: block.timestamp + 1 hours,
+            allowlistMintPrice: 0.015 ether,
+            publicMintPrice: 0.02 ether,
+            allowlistStageDuration: 2 days,
+            tokenURI: "https://test2.com/metadata/"
+        });
+        
+        address collection1 = erc721Factory.createERC721Collection(params1);
+        address collection2 = erc721Factory.createERC721Collection(params2);
+        
+        ERC721Collection col1 = ERC721Collection(collection1);
+        ERC721Collection col2 = ERC721Collection(collection2);
+        
+        // Verify first collection
+        assertEq(col1.name(), "First Collection");
+        assertEq(col1.symbol(), "FC");
+        
+        // Verify second collection
+        assertEq(col2.name(), "Second Collection");
+        assertEq(col2.symbol(), "SC");
+        
+        // Ensure they are different
+        assertTrue(collection1 != collection2, "Collections should have different addresses");
+    }
+}


### PR DESCRIPTION
Fixed the bug where name and symbol were not being stored correctly when creating collections through the proxy pattern. The issue was that ERC721/ERC1155 base contracts store these values in private variables that can't be accessed by proxy implementations.

Changes:
- Added s_collectionName and s_collectionSymbol state variables to ERC721Collection
- Override name() and symbol() functions to return these stored values
- Added _setNameAndSymbol() internal function for proxy initialization
- Updated both ERC721CollectionImplementation and ERC1155CollectionImplementation to call _setNameAndSymbol() during initialization
- Added comprehensive tests to verify name and symbol storage works correctly